### PR TITLE
Implement #38 Fragment 의 Injection 위치 재조정, Bottom nav 버그 수정

### DIFF
--- a/PRACTICE_JETPACK/app/src/main/java/nlab/practice/jetpack/ui/home/HomeViewModel.kt
+++ b/PRACTICE_JETPACK/app/src/main/java/nlab/practice/jetpack/ui/home/HomeViewModel.kt
@@ -41,12 +41,19 @@ class HomeViewModel @Inject constructor(
     }
 
     init {
-        _homeHeaderViewModel.startTimer()
         headers.add(_homeHeaderViewModel)
+        initializeTimer(fragmentLifeCycleBinder)
         refreshItems()
 
         containerFragmentCallback.onBottomNavReselected(this::scrollToZeroIfEmptyChild)
-        fragmentLifeCycleBinder.bindUntil(FragmentLifeCycle.ON_DESTROY) { _homeHeaderViewModel.stopTimer() }
+    }
+
+    private fun initializeTimer(fragmentLifeCycleBinder: FragmentLifeCycleBinder) {
+        _homeHeaderViewModel.startTimer()
+
+        fragmentLifeCycleBinder.bindUntil(FragmentLifeCycle.ON_DESTROY_VIEW) {
+            _homeHeaderViewModel.stopTimer()
+        }
     }
 
     private fun scrollToZeroIfEmptyChild(): Boolean {

--- a/PRACTICE_JETPACK/app/src/main/java/nlab/practice/jetpack/ui/main/MainBottomNavUsecase.kt
+++ b/PRACTICE_JETPACK/app/src/main/java/nlab/practice/jetpack/ui/main/MainBottomNavUsecase.kt
@@ -22,25 +22,38 @@ class MainBottomNavUsecase(private val _navController: MainNavController, viewSu
 
     fun initialize() {
         _bottomNavigationView.setOnNavigationItemSelectedListener(this)
-        navFirstPage()
-
         _bottomNavigationView.setOnNavigationItemReselectedListener(this)
     }
 
     fun navFirstPage() {
-        _bottomNavigationView.selectedItemId = R.id.menu_home
+        navPage(R.id.menu_home)
+    }
+
+    fun navPage(@IdRes menuRes: Int) {
+        _bottomNavigationView.selectedItemId = menuRes
+
+        onNavigationItemSelected(menuRes)
     }
 
     @IdRes
     fun getSelectedItemId(): Int =_bottomNavigationView.selectedItemId
 
-    override fun onNavigationItemSelected(updateMenu: MenuItem): Boolean = when (updateMenu.itemId) {
+    override fun onNavigationItemSelected(updateMenu: MenuItem) = onNavigationItemSelected(updateMenu.itemId)
+
+    private fun onNavigationItemSelected(@IdRes menuRes: Int): Boolean = when(menuRes) {
         R.id.menu_home -> {
-            _navController.replacePrimaryFragment(HomeFragment::class.fragmentTag()) { HomeFragment() }
+            _navController.replacePrimaryFragment(HomeFragment::class.fragmentTag()) {
+                HomeFragment()
+            }
+
             true
         }
-        R.id.menu_history ->  {
-            _navController.replacePrimaryFragment(HistoryFragment::class.fragmentTag()) { HistoryFragment() }
+
+        R.id.menu_history -> {
+            _navController.replacePrimaryFragment(HistoryFragment::class.fragmentTag()) {
+                HistoryFragment()
+            }
+
             true
         }
 
@@ -48,12 +61,14 @@ class MainBottomNavUsecase(private val _navController: MainNavController, viewSu
     }
 
     override fun onNavigationItemReselected(updateMenu: MenuItem) {
-        _navController.getCurrentContainerFragment()?.run {
-            val result = onBottomNavReselected()
-            if (!result) {
-                getChildNavController().clearFragments()
-            }
-        }
+        _navController.getCurrentContainerFragment()
+                ?.run {
+                    val result = onBottomNavReselected()
+                    if (!result) {
+                        getChildNavController().clearFragments()
+                    }
+                }
+                ?: run { onNavigationItemSelected(updateMenu.itemId) }
     }
 
     fun onBackPressedInPrimaryNav(): Boolean = _navController.getCurrentContainerFragment()?.onBackPressed()?:false

--- a/PRACTICE_JETPACK/app/src/main/java/nlab/practice/jetpack/ui/main/MainHolderViewModel.kt
+++ b/PRACTICE_JETPACK/app/src/main/java/nlab/practice/jetpack/ui/main/MainHolderViewModel.kt
@@ -18,11 +18,14 @@ class MainHolderViewModel @Inject constructor(
         private val _mainNavUsecase: MainBottomNavUsecase): BaseObservable() {
 
     init {
-        activityLifeCycleBinder.bindUntil(ActivityLifeCycle.ON_CREATE) {
-            _mainNavUsecase.initialize()
-        }
-
+        activityLifeCycleBinder.bindUntil(ActivityLifeCycle.ON_CREATE) { executeOnCreate() }
         activityCallback.onBackPressed(this::executeOnBackPressed)
+        activityCallback.onRestoreInstanceState { executeOnRestoreInstanceState() }
+    }
+
+    private fun executeOnCreate() = with(_mainNavUsecase) {
+        initialize()
+        navFirstPage()
     }
 
     private fun executeOnBackPressed(): Boolean = when {
@@ -38,4 +41,7 @@ class MainHolderViewModel @Inject constructor(
         // 그 외 거짓
         else -> false
     }
+
+    private fun executeOnRestoreInstanceState() = with(_mainNavUsecase) { navPage(getSelectedItemId()) }
+
 }

--- a/PRACTICE_JETPACK/app/src/main/java/nlab/practice/jetpack/util/component/callback/ActivityCallback.kt
+++ b/PRACTICE_JETPACK/app/src/main/java/nlab/practice/jetpack/util/component/callback/ActivityCallback.kt
@@ -1,5 +1,7 @@
 package nlab.practice.jetpack.util.component.callback
 
+import android.os.Bundle
+
 /**
  * Activity 의 Callback 에 대한 연결자 정의
  *
@@ -8,10 +10,17 @@ package nlab.practice.jetpack.util.component.callback
 class ActivityCallback {
 
     var onBackPressedCommand: (()-> Boolean)? = null
-    private set
+        private set
+
+    var onRestoreInstanceStateCommand: ((savedInstanceState: Bundle?) -> Unit)? = null
+        private set
 
     fun onBackPressed(action: () -> Boolean) {
        onBackPressedCommand = action
+    }
+
+    fun onRestoreInstanceState(action: (savedInstanceState: Bundle?) -> Unit) {
+        onRestoreInstanceStateCommand = action
     }
 }
 

--- a/PRACTICE_JETPACK/app/src/main/java/nlab/practice/jetpack/util/component/lifecycle/FragmentLifeCycle.kt
+++ b/PRACTICE_JETPACK/app/src/main/java/nlab/practice/jetpack/util/component/lifecycle/FragmentLifeCycle.kt
@@ -6,8 +6,6 @@ package nlab.practice.jetpack.util.component.lifecycle
  * @author Doohyun
  */
 enum class FragmentLifeCycle {
-    ON_ATTACH,
-    ON_CREATE,
     ON_CREATE_VIEW,
     ON_ACTIVITY_CREATED,
     ON_VIEW_CREATED,
@@ -15,9 +13,7 @@ enum class FragmentLifeCycle {
     ON_RESUME,
     ON_PAUSE,
     ON_STOP,
-    ON_DESTROY_VIEW,
-    ON_DESTROY,
-    ON_DETACH
+    ON_DESTROY_VIEW
 }
 
 typealias FragmentLifeCycleBinder = LifeCycleBinder<FragmentLifeCycle>

--- a/PRACTICE_JETPACK/app/src/main/java/nlab/practice/jetpack/util/di/activity/ActivityInjector.kt
+++ b/PRACTICE_JETPACK/app/src/main/java/nlab/practice/jetpack/util/di/activity/ActivityInjector.kt
@@ -13,7 +13,7 @@ object ActivityInjector : AndroidInjector<Activity> {
 
     override fun inject(activity: Activity?) {
        activity?.let { it as InjectableActivity }
-               ?.getActivityBindComponent()
+               ?.activityBindComponent
                ?.activityInjector()
                ?.maybeInject(activity)
     }

--- a/PRACTICE_JETPACK/app/src/main/java/nlab/practice/jetpack/util/di/fragment/FragmentInjector.kt
+++ b/PRACTICE_JETPACK/app/src/main/java/nlab/practice/jetpack/util/di/fragment/FragmentInjector.kt
@@ -12,7 +12,7 @@ object FragmentInjector : AndroidInjector<Fragment> {
 
     override fun inject(fragment: Fragment?) {
         fragment?.let { it as InjectableFragment }
-                ?.getFragmentBindComponent()
+                ?.fragmentBindComponent
                 ?.activityInjector()
                 ?.maybeInject(fragment)
     }


### PR DESCRIPTION
#38 에 대한 이슈 수정

### Fragment lifecycle 조정결과
- onCreateView - onDestroyView 이전과 이후 콜백은 사용할 수 없음. 필요하다면, 다시 고민해봐야함